### PR TITLE
fix: nginx reverse proxy so frontend works from any PC

### DIFF
--- a/padel-frontend/nginx.conf
+++ b/padel-frontend/nginx.conf
@@ -4,6 +4,30 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    location /api/ {
+        proxy_pass http://backend:8080/api/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    location /terrains {
+        proxy_pass http://backend:8080/terrains;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    location /utilisateurs {
+        proxy_pass http://backend:8080/utilisateurs;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    location /sites {
+        proxy_pass http://backend:8080/sites;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
     location / {
         try_files $uri $uri/ /index.html;
     }

--- a/padel-frontend/src/environments/environment.production.ts
+++ b/padel-frontend/src/environments/environment.production.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: true,
-  apiBaseUrl: 'http://localhost:8080'
+  apiBaseUrl: ''
 };
 


### PR DESCRIPTION
- environment.production.ts: apiBaseUrl set to '' (relative URLs)
- nginx.conf: proxy /api/, /terrains, /utilisateurs, /sites to backend:8080